### PR TITLE
Focusing `textarea` after inserting mermaid widget

### DIFF
--- a/src/commands/insertMermaidCommand.js
+++ b/src/commands/insertMermaidCommand.js
@@ -36,16 +36,17 @@ export default class InsertMermaidCommand extends Command {
 	execute() {
 		const editor = this.editor;
 		const model = editor.model;
+		let mermaidItem;
 
 		model.change( writer => {
-			const item = writer.createElement( 'mermaid', {
+			mermaidItem = writer.createElement( 'mermaid', {
 				displayMode: 'split',
 				source: MOCK_MERMAID_MARKUP
 			} );
 
-			model.insertContent( item );
+			model.insertContent( mermaidItem );
 		} );
 
-		editor.editing.view.focus();
+		return mermaidItem;
 	}
 }

--- a/src/mermaidui.js
+++ b/src/mermaidui.js
@@ -69,7 +69,11 @@ export default class MermaidUI extends Plugin {
 			command.listenTo( buttonView, 'execute', () => {
 				const mermaidItem = editor.execute( 'insertMermaidCommand' );
 				const mermaidItemViewElement = editor.editing.mapper.toViewElement( mermaidItem );
-				const mermaidItemDomElement = view.domConverter.viewToDom( mermaidItemViewElement, document );
+				let mermaidItemDomElement;
+
+				if ( mermaidItemViewElement ) {
+					mermaidItemDomElement = view.domConverter.viewToDom( mermaidItemViewElement, document );
+				}
 
 				view.scrollToTheSelection();
 				view.focus();

--- a/src/mermaidui.js
+++ b/src/mermaidui.js
@@ -69,17 +69,16 @@ export default class MermaidUI extends Plugin {
 			command.listenTo( buttonView, 'execute', () => {
 				const mermaidItem = editor.execute( 'insertMermaidCommand' );
 				const mermaidItemViewElement = editor.editing.mapper.toViewElement( mermaidItem );
-				let mermaidItemDomElement;
-
-				if ( mermaidItemViewElement ) {
-					mermaidItemDomElement = view.domConverter.viewToDom( mermaidItemViewElement, document );
-				}
 
 				view.scrollToTheSelection();
 				view.focus();
 
-				if ( mermaidItemDomElement ) {
-					mermaidItemDomElement.querySelector( '.ck-mermaid__editing-view' ).focus();
+				if ( mermaidItemViewElement ) {
+					const mermaidItemDomElement = view.domConverter.viewToDom( mermaidItemViewElement, document );
+
+					if ( mermaidItemDomElement ) {
+						mermaidItemDomElement.querySelector( '.ck-mermaid__editing-view' ).focus();
+					}
 				}
 			} );
 

--- a/src/mermaidui.js
+++ b/src/mermaidui.js
@@ -11,7 +11,7 @@ import splitModeIcon from '../theme/icons/split-mode.svg';
 import sourceModeIcon from '../theme/icons/source-mode.svg';
 import infoIcon from '../theme/icons/info.svg';
 
-/* global window */
+/* global window, document */
 
 export default class MermaidUI extends Plugin {
 	/**
@@ -51,6 +51,7 @@ export default class MermaidUI extends Plugin {
 	_addInsertMermaidButton() {
 		const editor = this.editor;
 		const t = editor.t;
+		const view = editor.editing.view;
 
 		editor.ui.componentFactory.add( 'mermaid', locale => {
 			const buttonView = new ButtonView( locale );
@@ -66,9 +67,16 @@ export default class MermaidUI extends Plugin {
 
 			// Execute the command when the button is clicked.
 			command.listenTo( buttonView, 'execute', () => {
-				editor.execute( 'insertMermaidCommand' );
-				editor.editing.view.scrollToTheSelection();
-				editor.editing.view.focus();
+				const mermaidItem = editor.execute( 'insertMermaidCommand' );
+				const mermaidItemViewElement = editor.editing.mapper.toViewElement( mermaidItem );
+				const mermaidItemDomElement = view.domConverter.viewToDom( mermaidItemViewElement, document );
+
+				view.scrollToTheSelection();
+				view.focus();
+
+				if ( mermaidItemDomElement ) {
+					mermaidItemDomElement.querySelector( '.ck-mermaid__editing-view' ).focus();
+				}
 			} );
 
 			return buttonView;

--- a/tests/mermaidui.js
+++ b/tests/mermaidui.js
@@ -1,4 +1,6 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
 
 import Mermaid from '../src/mermaid';
 import MermaidUI from '../src/mermaidui';
@@ -19,7 +21,8 @@ describe( 'MermaidUI', () => {
 
 			editor = await ClassicEditor.create( domElement, {
 				plugins: [
-					Mermaid
+					Mermaid,
+					Paragraph
 				]
 			} );
 		} );
@@ -60,6 +63,29 @@ describe( 'MermaidUI', () => {
 					expect( button ).to.have.property( 'tooltip', true );
 				} );
 			}
+		} );
+
+		it( 'should set focus inside textarea of a newly created mermaid', () => {
+			const button = editor.ui.componentFactory.create( 'mermaid' );
+
+			button.fire( 'execute' );
+
+			expect( document.activeElement.tagName ).to.equal( 'TEXTAREA' );
+		} );
+
+		it( 'should not crash if the button is fired inside model.change()', () => {
+			const button = editor.ui.componentFactory.create( 'mermaid' );
+
+			setModelData( editor.model,
+				'<paragraph>[foo]</paragraph>'
+			);
+
+			editor.model.change( () => {
+				button.fire( 'execute' );
+			} );
+			// As the conversion is to be executed after the model.change(), we don't have access to the fully prepared view and
+			// despite that, we should still successfully add mermaid widget to the editor, not requiring the selection change
+			// to the inside of the nonexisting textarea element.
 		} );
 	} );
 } );

--- a/tests/mermaidui.js
+++ b/tests/mermaidui.js
@@ -1,6 +1,5 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import Mermaid from '../src/mermaid';
 import MermaidUI from '../src/mermaidui';
@@ -21,8 +20,7 @@ describe( 'MermaidUI', () => {
 
 			editor = await ClassicEditor.create( domElement, {
 				plugins: [
-					Mermaid,
-					Paragraph
+					Mermaid
 				]
 			} );
 		} );
@@ -76,9 +74,7 @@ describe( 'MermaidUI', () => {
 		it( 'should not crash if the button is fired inside model.change()', () => {
 			const button = editor.ui.componentFactory.create( 'mermaid' );
 
-			setModelData( editor.model,
-				'<paragraph>[foo]</paragraph>'
-			);
+			setModelData( editor.model, '[]' );
 
 			editor.model.change( () => {
 				button.fire( 'execute' );


### PR DESCRIPTION
The widget no longer needs to be clicked after being inserted before writing mermaid code is possible, as the focus will be inside of the `textarea` element when possible.