### PR TITLE
Postpone rendering the diagram until DOM element is visible.

### DIFF
--- a/src/mermaidediting.js
+++ b/src/mermaidediting.js
@@ -194,10 +194,19 @@ export default class MermaidEditing extends Plugin {
 
 			domElement.innerHTML = mermaidSource;
 
-			window.setTimeout( () => {
-				// @todo: by the looks of it the domElement needs to be hooked to tree in order to allow for rendering.
+			// Rendering mermaid diagram won't be successful if the domElement is invisible.
+			// Instead of rendering it right away (or with a fixed timeout), let's postpone rendering until the domElement is visible.
+			// https://github.com/ckeditor/github-writer/issues/379
+			if ( !domElement.getBoundingClientRect().height ) {
+				const resizeObserver = new window.ResizeObserver( () => {
+					that._renderMermaid( domElement );
+					resizeObserver.unobserve( domElement );
+				} );
+
+				resizeObserver.observe( domElement );
+			} else {
 				that._renderMermaid( domElement );
-			}, 100 );
+			}
 
 			return domElement;
 		}


### PR DESCRIPTION
Postpones rendering the diagram until DOM element is visible.

Original issue: ckeditor/github-writer#379.  
This will solve the issue in GitHub Writer with rendering the diagram when editing the comment containing it.