### PR TITLE
Migration reflected from `ckeditor5-package-generator` to support only NIM.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,5 +21,8 @@ module.exports = {
 				'ckeditor5-rules/ckeditor-imports': 'off'
 			}
 		}
+	],
+	ignorePatterns: [
+		'dist/**'
 	]
 };

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ coverage/
 node_modules/
 yarn.lock
 tmp/
-build/
+dist/
 yarn.error

--- a/package.json
+++ b/package.json
@@ -13,6 +13,17 @@
   ],
   "type": "module",
   "main": "dist/index.js",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    },
+    "./translations/*.js": {
+      "import": "./dist/translations/*.js"
+    },
+    "./*.css": "./dist/*.css",
+    "./package.json": "./package.json"
+  },
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "CKSource (https://cksource.com/)",
   "homepage": "https://github.com/ckeditor/ckeditor5-mermaid",
@@ -27,9 +38,6 @@
   "dependencies": {
     "mermaid": "9.1.7",
     "lodash-es": "^4.17.15"
-  },
-  "peerDependencies": {
-    "ckeditor5": "*"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-build-tools": "^40.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-build-tools": "^40.0.0",
-    "@ckeditor/ckeditor5-package-tools": "file:/Users/piotrszczesniak/Dev/ckeditor5-package-generator/packages/ckeditor5-package-tools",
+    "@ckeditor/ckeditor5-package-tools": "^1.1.0",
     "ckeditor5": "nightly",
     "eslint": "^7.32.0",
     "eslint-config-ckeditor5": ">=3.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-build-tools": "^40.0.0",
+    "@ckeditor/ckeditor5-inspector": "^4.0.0",
     "@ckeditor/ckeditor5-package-tools": "^1.1.0",
     "ckeditor5": "nightly",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -11,21 +11,18 @@
     "ckeditor5-plugin",
     "ckeditor5-mermaid"
   ],
-  "main": "src/index.js",
+  "type": "module",
+  "main": "dist/index.js",
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "CKSource (https://cksource.com/)",
   "homepage": "https://github.com/ckeditor/ckeditor5-mermaid",
   "bugs": "https://github.com/ckeditor/ckeditor5-mermaid/issues",
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=18.0.0",
     "npm": ">=5.7.1"
   },
   "files": [
-    "lang",
-    "src",
-    "theme",
-    "build",
-    "ckeditor5-metadata.json"
+    "dist"
   ],
   "dependencies": {
     "mermaid": "9.1.7",
@@ -35,23 +32,9 @@
     "ckeditor5": "*"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-basic-styles": "^35.0.1",
-    "@ckeditor/ckeditor5-clipboard": "^35.0.1",
-    "@ckeditor/ckeditor5-code-block": "^35.0.1",
-    "@ckeditor/ckeditor5-editor-classic": "^35.0.1",
-    "@ckeditor/ckeditor5-engine": "^35.0.1",
-    "@ckeditor/ckeditor5-enter": "^35.0.1",
-    "@ckeditor/ckeditor5-essentials": "^35.0.1",
-    "@ckeditor/ckeditor5-heading": "^35.0.1",
-    "@ckeditor/ckeditor5-inspector": "^4.0.0",
-    "@ckeditor/ckeditor5-link": "^35.0.1",
-    "@ckeditor/ckeditor5-markdown-gfm": "^35.0.1",
-    "@ckeditor/ckeditor5-paragraph": "^35.0.1",
-    "@ckeditor/ckeditor5-typing": "^35.0.1",
-    "@ckeditor/ckeditor5-undo": "^35.0.1",
-    "@ckeditor/ckeditor5-widget": "^35.0.1",
-    "@ckeditor/ckeditor5-package-tools": "^1.0.0-beta.4",
-    "@ckeditor/ckeditor5-theme-lark": "^35.0.1",
+    "@ckeditor/ckeditor5-dev-build-tools": "^40.0.0",
+    "@ckeditor/ckeditor5-package-tools": "file:/Users/piotrszczesniak/Dev/ckeditor5-package-generator/packages/ckeditor5-package-tools",
+    "ckeditor5": "nightly",
     "eslint": "^7.32.0",
     "eslint-config-ckeditor5": ">=3.1.1",
     "http-server": "^14.1.0",
@@ -62,14 +45,12 @@
   },
 
   "scripts": {
-    "dll:build": "ckeditor5-package-tools dll:build",
-    "dll:serve": "http-server ./ -o sample/dll.html",
+    "build:dist": "node ./scripts/build-dist.mjs",
     "lint": "eslint \"**/*.js\" --quiet --ignore-pattern \"build/\"",
     "start": "ckeditor5-package-tools start",
     "stylelint": "stylelint --quiet --allow-empty-input 'theme/*.css'",
     "test": "ckeditor5-package-tools test",
-    "prepare": "yarn run dll:build",
-    "prepublishOnly": "yarn run dll:build",
+    "prepare": "yarn run build:dist",
     "translations:collect": "ckeditor5-package-tools translations:collect",
     "translations:download": "ckeditor5-package-tools translations:download",
     "translations:upload": "ckeditor5-package-tools translations:upload"

--- a/sample/ckeditor.js
+++ b/sample/ckeditor.js
@@ -22,6 +22,8 @@ import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 
 import Mermaid from '../src/mermaid.js';
 
+import 'ckeditor5/index.css';
+
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [

--- a/sample/ckeditor.js
+++ b/sample/ckeditor.js
@@ -5,19 +5,22 @@
 
 /* globals console, window, document */
 
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import Typing from '@ckeditor/ckeditor5-typing/src/typing';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Undo from '@ckeditor/ckeditor5-undo/src/undo';
-import Enter from '@ckeditor/ckeditor5-enter/src/enter';
-import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
-import Link from '@ckeditor/ckeditor5-link/src/link';
-import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import {
+	ClassicEditor,
+	Typing,
+	Undo,
+	Enter,
+	Clipboard,
+	Link,
+	Bold,
+	Italic,
+	Paragraph,
+	CodeBlock
+} from 'ckeditor5';
+
 import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
 
-import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
-import Mermaid from '../src/mermaid';
+import Mermaid from '../src/mermaid.js';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2020-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* eslint-env node */
+
+import { createRequire } from 'module';
+import upath from 'upath';
+import chalk from 'chalk';
+import { build } from '@ckeditor/ckeditor5-dev-build-tools';
+
+function dist( path ) {
+	return upath.join( 'dist', path );
+}
+
+( async () => {
+	/**
+	 * Step 1
+	 */
+	console.log( chalk.cyan( '1/2: Generating NPM build...' ) );
+
+	const require = createRequire( import.meta.url );
+	const pkg = require( upath.resolve( process.cwd(), './package.json' ) );
+
+	await build( {
+		input: 'src/index.js',
+		output: dist( './index.js' ),
+		external: [
+			'ckeditor5',
+			'ckeditor5-premium-features',
+			...Object.keys( {
+				...pkg.dependencies,
+				...pkg.peerDependencies
+			} )
+		],
+		clean: true,
+		sourceMap: true,
+		translations: '**/*.po'
+	} );
+
+	/**
+	 * Step 2
+	 */
+	console.log( chalk.cyan( '2/2: Generating browser build...' ) );
+
+	await build( {
+		input: 'src/index.js',
+		output: dist( 'browser/index.js' ),
+		sourceMap: true,
+		minify: true,
+		browser: true,
+		name: '@ckeditor/ckeditor5-mermaid',
+		external: [
+			'ckeditor5',
+			'ckeditor5-premium-features'
+		]
+	} );
+} )();

--- a/src/commands/insertMermaidCommand.js
+++ b/src/commands/insertMermaidCommand.js
@@ -2,7 +2,7 @@
  * @module mermaid/insertmermaidcommand
  */
 
-import { Command } from 'ckeditor5/src/core';
+import { Command } from 'ckeditor5';
 
 const MOCK_MERMAID_MARKUP = `flowchart TB
 A --> B

--- a/src/commands/mermaidPreviewCommand.js
+++ b/src/commands/mermaidPreviewCommand.js
@@ -2,9 +2,9 @@
  * @module mermaid/mermaidpreviewcommand
  */
 
-import { Command } from 'ckeditor5/src/core';
+import { Command } from 'ckeditor5';
 
-import { checkIsOn } from '../utils';
+import { checkIsOn } from '../utils.js';
 
 /**
  * The mermaid preview command.

--- a/src/commands/mermaidSourceViewCommand.js
+++ b/src/commands/mermaidSourceViewCommand.js
@@ -2,9 +2,9 @@
  * @module mermaid/mermaidsourceviewcommand
  */
 
-import { Command } from 'ckeditor5/src/core';
+import { Command } from 'ckeditor5';
 
-import { checkIsOn } from '../utils';
+import { checkIsOn } from '../utils.js';
 
 /**
  * The mermaid source view command.

--- a/src/commands/mermaidSplitViewCommand.js
+++ b/src/commands/mermaidSplitViewCommand.js
@@ -2,9 +2,9 @@
  * @module mermaid/mermaidsplitviewcommand
  */
 
-import { Command } from 'ckeditor5/src/core';
+import { Command } from 'ckeditor5';
 
-import { checkIsOn } from '../utils';
+import { checkIsOn } from '../utils.js';
 
 /**
  * The mermaid split view command.

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import previewModeIcon from './../theme/icons/preview-mode.svg';
 import splitModeIcon from './../theme/icons/split-mode.svg';
 import sourceModeIcon from './../theme/icons/source-mode.svg';
 
-export { default as Mermaid } from './mermaid';
+export { default as Mermaid } from './mermaid.js';
 
 export const icons = {
 	infoIcon,

--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -2,11 +2,11 @@
  * @module mermaid/mermaid
  */
 
-import { Plugin } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5';
 
-import MermaidEditing from './mermaidediting';
-import MermaidToolbar from './mermaidtoolbar';
-import MermaidUI from './mermaidui';
+import MermaidEditing from './mermaidediting.js';
+import MermaidToolbar from './mermaidtoolbar.js';
+import MermaidUI from './mermaidui.js';
 
 import '../theme/mermaid.css';
 

--- a/src/mermaidediting.js
+++ b/src/mermaidediting.js
@@ -2,17 +2,16 @@
  * @module mermaid/mermaidediting
  */
 
-import { Plugin } from 'ckeditor5/src/core';
-import { toWidget } from 'ckeditor5/src/widget';
+import { Plugin, toWidget } from 'ckeditor5';
 
-import mermaid from 'mermaid/dist/mermaid';
+import mermaid from 'mermaid/dist/mermaid.js';
 
 import { debounce } from 'lodash-es';
 
-import MermaidPreviewCommand from './commands/mermaidPreviewCommand';
-import MermaidSourceViewCommand from './commands/mermaidSourceViewCommand';
-import MermaidSplitViewCommand from './commands/mermaidSplitViewCommand';
-import InsertMermaidCommand from './commands/insertMermaidCommand';
+import MermaidPreviewCommand from './commands/mermaidPreviewCommand.js';
+import MermaidSourceViewCommand from './commands/mermaidSourceViewCommand.js';
+import MermaidSplitViewCommand from './commands/mermaidSplitViewCommand.js';
+import InsertMermaidCommand from './commands/insertMermaidCommand.js';
 
 // Time in milliseconds.
 const DEBOUNCE_TIME = 300;

--- a/src/mermaidtoolbar.js
+++ b/src/mermaidtoolbar.js
@@ -2,8 +2,7 @@
  * @module mermaid/mermaidtoolbar
  */
 
-import { Plugin } from 'ckeditor5/src/core';
-import { WidgetToolbarRepository } from 'ckeditor5/src/widget';
+import { Plugin, WidgetToolbarRepository } from 'ckeditor5';
 
 export default class MermaidToolbar extends Plugin {
 	/**

--- a/src/mermaidui.js
+++ b/src/mermaidui.js
@@ -2,8 +2,7 @@
  * @module mermaid/mermaidui
  */
 
-import { Plugin } from 'ckeditor5/src/core';
-import { ButtonView } from 'ckeditor5/src/ui';
+import { ButtonView, Plugin } from 'ckeditor5';
 
 import insertMermaidIcon from '../theme/icons/insert.svg';
 import previewModeIcon from '../theme/icons/preview-mode.svg';

--- a/tests/commands/insertMermaidCommand.js
+++ b/tests/commands/insertMermaidCommand.js
@@ -1,9 +1,12 @@
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import {
+	ClassicEditor,
+	Paragraph,
+	_setModelData as setModelData,
+	_getModelData as getModelData
+} from 'ckeditor5';
 
-import InsertMermaidCommand from '../../src/commands/insertMermaidCommand';
-import MermaidEditing from '../../src/mermaidediting';
+import InsertMermaidCommand from '../../src/commands/insertMermaidCommand.js';
+import MermaidEditing from '../../src/mermaidediting.js';
 
 /* global document */
 

--- a/tests/commands/mermaidPreviewCommand.js
+++ b/tests/commands/mermaidPreviewCommand.js
@@ -1,9 +1,12 @@
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import {
+	ClassicEditor,
+	Paragraph,
+	_setModelData as setModelData,
+	_getModelData as getModelData
+} from 'ckeditor5';
 
-import MermaidPreviewCommand from '../../src/commands/mermaidPreviewCommand';
-import MermaidEditing from '../../src/mermaidediting';
+import MermaidPreviewCommand from '../../src/commands/mermaidPreviewCommand.js';
+import MermaidEditing from '../../src/mermaidediting.js';
 
 /* global document */
 

--- a/tests/commands/mermaidSourceViewCommand.js
+++ b/tests/commands/mermaidSourceViewCommand.js
@@ -1,9 +1,12 @@
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import {
+	ClassicEditor,
+	Paragraph,
+	_setModelData as setModelData,
+	_getModelData as getModelData
+} from 'ckeditor5';
 
-import MermaidSourceViewCommand from '../../src/commands/mermaidSourceViewCommand';
-import MermaidEditing from '../../src/mermaidediting';
+import MermaidSourceViewCommand from '../../src/commands/mermaidSourceViewCommand.js';
+import MermaidEditing from '../../src/mermaidediting.js';
 
 /* global document */
 

--- a/tests/commands/mermaidSplitViewCommand.js
+++ b/tests/commands/mermaidSplitViewCommand.js
@@ -1,9 +1,12 @@
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+import {
+	ClassicEditor,
+	Paragraph,
+	_setModelData as setModelData,
+	_getModelData as getModelData
+} from 'ckeditor5';
 
-import MermaidSplitViewCommand from '../../src/commands/mermaidSplitViewCommand';
-import MermaidEditing from '../../src/mermaidediting';
+import MermaidSplitViewCommand from '../../src/commands/mermaidSplitViewCommand.js';
+import MermaidEditing from '../../src/mermaidediting.js';
 
 /* global document */
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,5 @@
-import { Mermaid as MermaidDll, icons } from '../src';
-import Mermaid from '../src/mermaid';
+import { Mermaid as MermaidDll, icons } from '../src/index.js';
+import Mermaid from '../src/mermaid.js';
 
 import infoIcon from './../theme/icons/info.svg';
 import insertMermaidIcon from './../theme/icons/insert.svg';

--- a/tests/manual/markdown.js
+++ b/tests/manual/markdown.js
@@ -5,19 +5,21 @@
 
 /* globals console, window, document */
 
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import Typing from '@ckeditor/ckeditor5-typing/src/typing';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Undo from '@ckeditor/ckeditor5-undo/src/undo';
-import Enter from '@ckeditor/ckeditor5-enter/src/enter';
-import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
-import Link from '@ckeditor/ckeditor5-link/src/link';
-import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-import Markdown from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
+import {
+	ClassicEditor,
+	CodeBlock,
+	Typing,
+	Paragraph,
+	Undo,
+	Enter,
+	Clipboard,
+	Link,
+	Bold,
+	Italic,
+	Markdown
+} from 'ckeditor5';
 
-import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
-import Mermaid from '../../src/mermaid';
+import Mermaid from '../../src/mermaid.js';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {

--- a/tests/manual/mermaid.js
+++ b/tests/manual/mermaid.js
@@ -5,18 +5,20 @@
 
 /* globals console, window, document */
 
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import Typing from '@ckeditor/ckeditor5-typing/src/typing';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Undo from '@ckeditor/ckeditor5-undo/src/undo';
-import Enter from '@ckeditor/ckeditor5-enter/src/enter';
-import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
-import Link from '@ckeditor/ckeditor5-link/src/link';
-import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import {
+	ClassicEditor,
+	CodeBlock,
+	Typing,
+	Paragraph,
+	Undo,
+	Enter,
+	Clipboard,
+	Link,
+	Bold,
+	Italic
+} from 'ckeditor5';
 
-import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
-import Mermaid from '../../src/mermaid';
+import Mermaid from '../../src/mermaid.js';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {

--- a/tests/mermaid.js
+++ b/tests/mermaid.js
@@ -1,10 +1,12 @@
-import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Heading from '@ckeditor/ckeditor5-heading/src/heading';
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import Mermaid from '../src/mermaid';
+import {
+	ClassicEditor,
+	Essentials,
+	Heading,
+	Paragraph,
+	_setModelData as setModelData
+} from 'ckeditor5';
 
-import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import Mermaid from '../src/mermaid';
 
 /* global document */
 

--- a/tests/mermaidediting.js
+++ b/tests/mermaidediting.js
@@ -1,10 +1,14 @@
-import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Heading from '@ckeditor/ckeditor5-heading/src/heading';
-import { setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
-import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import {
+	ClassicEditor,
+	CodeBlockEditing,
+	Essentials,
+	Heading,
+	Paragraph,
+	_setModelData as setModelData,
+	_getModelData as getModelData,
+	_getViewData as getViewData
+} from 'ckeditor5';
+
 import MermaidEditing from '../src/mermaidediting';
 
 /* global document */

--- a/tests/mermaidtoolbar.js
+++ b/tests/mermaidtoolbar.js
@@ -1,10 +1,10 @@
-import ClassicTestEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import {
-	setData
-} from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import WidgetToolbarRepository from '@ckeditor/ckeditor5-widget/src/widgettoolbarrepository';
-import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-import { Paragraph } from '@ckeditor/ckeditor5-paragraph';
+	ClassicEditor as ClassicTestEditor,
+	Essentials,
+	Paragraph,
+	WidgetToolbarRepository,
+	_setModelData as setData
+} from 'ckeditor5';
 
 import Mermaid from '../src/mermaid';
 

--- a/tests/mermaidui.js
+++ b/tests/mermaidui.js
@@ -1,8 +1,7 @@
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { ClassicEditor, _setModelData as setModelData } from 'ckeditor5';
 
-import Mermaid from '../src/mermaid';
-import MermaidUI from '../src/mermaidui';
+import Mermaid from '../src/mermaid.js';
+import MermaidUI from '../src/mermaidui.js';
 
 /* global document */
 


### PR DESCRIPTION
:warning: DO NOT MERGE :warning: 

It will properly work when new version of `ckeditor5-package-generator` will be released.

---

Migrated package that's reflected changes in `ckeditor5-package-generator` with dropping support for current build methods (DLL) and support only NIM.